### PR TITLE
Feature/account fields

### DIFF
--- a/force-app/main/default/globalValueSets/Degree_Type.globalValueSet-meta.xml
+++ b/force-app/main/default/globalValueSets/Degree_Type.globalValueSet-meta.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<GlobalValueSet xmlns="http://soap.sforce.com/2006/04/metadata">
+    <customValue>
+        <fullName>Degree</fullName>
+        <default>false</default>
+        <label>Degree</label>
+    </customValue>
+    <customValue>
+        <fullName>Certificate</fullName>
+        <default>false</default>
+        <label>Certificate</label>
+    </customValue>
+    <customValue>
+        <fullName>Badge</fullName>
+        <default>false</default>
+        <label>Badge</label>
+    </customValue>
+    <customValue>
+        <fullName>Other</fullName>
+        <default>false</default>
+        <label>Other</label>
+    </customValue>
+    <description>The type of academic program.</description>
+    <masterLabel>Degree Type</masterLabel>
+    <sorted>false</sorted>
+</GlobalValueSet>

--- a/force-app/main/default/globalValueSets/Program_Level.globalValueSet-meta.xml
+++ b/force-app/main/default/globalValueSets/Program_Level.globalValueSet-meta.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<GlobalValueSet xmlns="http://soap.sforce.com/2006/04/metadata">
+    <customValue>
+        <fullName>UG</fullName>
+        <default>false</default>
+        <label>UG</label>
+    </customValue>
+    <customValue>
+        <fullName>GR</fullName>
+        <default>false</default>
+        <label>GR</label>
+    </customValue>
+    <customValue>
+        <fullName>NC</fullName>
+        <default>false</default>
+        <label>NC</label>
+    </customValue>
+    <customValue>
+        <fullName>PHD</fullName>
+        <default>false</default>
+        <label>PHD</label>
+    </customValue>
+    <description>The level of an academic program.</description>
+    <masterLabel>Program Level</masterLabel>
+    <sorted>false</sorted>
+</GlobalValueSet>

--- a/force-app/main/default/globalValueSets/Unit_Type.globalValueSet-meta.xml
+++ b/force-app/main/default/globalValueSets/Unit_Type.globalValueSet-meta.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<GlobalValueSet xmlns="http://soap.sforce.com/2006/04/metadata">
+    <customValue>
+        <fullName>Credit</fullName>
+        <default>false</default>
+        <label>Credit</label>
+    </customValue>
+    <customValue>
+        <fullName>NonCredit</fullName>
+        <default>false</default>
+        <label>NonCredit</label>
+    </customValue>
+    <description>The unit type for an academic program.</description>
+    <masterLabel>Unit Type</masterLabel>
+    <sorted>false</sorted>
+</GlobalValueSet>

--- a/force-app/main/default/objects/Account/fields/CSU_Online_Program__c.field-meta.xml
+++ b/force-app/main/default/objects/Account/fields/CSU_Online_Program__c.field-meta.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
+    <fullName>CSU_Online_Program__c</fullName>
+    <defaultValue>false</defaultValue>
+    <externalId>false</externalId>
+    <inlineHelpText>Used to designate programs supported by the CSU Online team.</inlineHelpText>
+    <label>CSU Online Program</label>
+    <trackFeedHistory>false</trackFeedHistory>
+    <trackHistory>true</trackHistory>
+    <type>Checkbox</type>
+</CustomField>

--- a/force-app/main/default/objects/Account/fields/Hand_Off_Program__c.field-meta.xml
+++ b/force-app/main/default/objects/Account/fields/Hand_Off_Program__c.field-meta.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
+    <fullName>Hand_Off_Program__c</fullName>
+    <defaultValue>false</defaultValue>
+    <externalId>false</externalId>
+    <label>Hand Off Program</label>
+    <trackFeedHistory>false</trackFeedHistory>
+    <trackHistory>false</trackHistory>
+    <type>Checkbox</type>
+</CustomField>

--- a/force-app/main/default/objects/Account/fields/Program_Friendly_Name__c.field-meta.xml
+++ b/force-app/main/default/objects/Account/fields/Program_Friendly_Name__c.field-meta.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
+    <fullName>Program_Friendly_Name__c</fullName>
+    <description>The friendly name of an academic program, for use in merge fields with the &apos;Title Prefix&apos;.</description>
+    <externalId>false</externalId>
+    <inlineHelpText>The friendly name of an academic program, for use in merge fields with the &apos;Title Prefix&apos;.</inlineHelpText>
+    <label>Program Friendly Name</label>
+    <length>50</length>
+    <required>false</required>
+    <trackFeedHistory>false</trackFeedHistory>
+    <trackHistory>false</trackHistory>
+    <type>Text</type>
+    <unique>false</unique>
+</CustomField>

--- a/force-app/main/default/objects/Account/fields/Program_Level__c.field-meta.xml
+++ b/force-app/main/default/objects/Account/fields/Program_Level__c.field-meta.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
+    <fullName>Program_Level__c</fullName>
+    <description>The level of an academic program.</description>
+    <externalId>false</externalId>
+    <inlineHelpText>The level of an academic program.</inlineHelpText>
+    <label>Program Level</label>
+    <required>false</required>
+    <trackFeedHistory>false</trackFeedHistory>
+    <trackHistory>false</trackHistory>
+    <type>Picklist</type>
+    <valueSet>
+        <restricted>true</restricted>
+        <valueSetName>Program_Level</valueSetName>
+    </valueSet>
+</CustomField>

--- a/force-app/main/default/objects/Account/fields/Program_Title_Prefix__c.field-meta.xml
+++ b/force-app/main/default/objects/Account/fields/Program_Title_Prefix__c.field-meta.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
+    <fullName>Program_Title_Prefix__c</fullName>
+    <description>The friendly name of an academic program, for use in merge fields with the &apos;Program Friendly Name&apos;.</description>
+    <externalId>false</externalId>
+    <inlineHelpText>The friendly name of an academic program, for use in merge fields with the &apos;Program Friendly Name&apos;.</inlineHelpText>
+    <label>Program Title Prefix</label>
+    <length>50</length>
+    <required>false</required>
+    <trackFeedHistory>false</trackFeedHistory>
+    <trackHistory>false</trackHistory>
+    <type>Text</type>
+    <unique>false</unique>
+</CustomField>

--- a/force-app/main/default/objects/Account/fields/Type__c.field-meta.xml
+++ b/force-app/main/default/objects/Account/fields/Type__c.field-meta.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
+    <fullName>Type__c</fullName>
+    <description>The type of academic program.</description>
+    <externalId>false</externalId>
+    <inlineHelpText>The type of academic program.</inlineHelpText>
+    <label>Degree Type</label>
+    <required>false</required>
+    <trackFeedHistory>false</trackFeedHistory>
+    <trackHistory>false</trackHistory>
+    <type>Picklist</type>
+    <valueSet>
+        <restricted>true</restricted>
+        <valueSetName>Degree_Type</valueSetName>
+    </valueSet>
+</CustomField>

--- a/force-app/main/default/objects/Account/fields/Unit_Type__c.field-meta.xml
+++ b/force-app/main/default/objects/Account/fields/Unit_Type__c.field-meta.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
+    <fullName>Unit_Type__c</fullName>
+    <description>The unit type of an academic program.</description>
+    <externalId>false</externalId>
+    <inlineHelpText>The unit type of an academic program.</inlineHelpText>
+    <label>Unit Type</label>
+    <required>false</required>
+    <trackFeedHistory>false</trackFeedHistory>
+    <trackHistory>false</trackHistory>
+    <type>Picklist</type>
+    <valueSet>
+        <restricted>true</restricted>
+        <valueSetName>Unit_Type</valueSetName>
+    </valueSet>
+</CustomField>


### PR DESCRIPTION

# Critical Changes

# Changes

* Adding relevant program fields for Account object for base "program" model within the org, included handoff and csu online program indicators as although these are used in a credit-specific way now, it may not be in the future when we expand NC programs to contain extension (separating csu_online = true as the one's our current PE team does) 
* Degree type label changed from Type to Degree Type, prevents confusion from base Type field, cannot remove yet (or centralize to the base type field) due to email template considerations
* Add global value sets for type__c (degree type, i.e., badge, cert, degree, other), program_level__c (UG,GR,NC,PHD), and unity_type__c (Credit or Noncredit)

# Issues Closed
