### PR TITLE
Reverted the type from pointing to GVS to standard

### DIFF
--- a/force-app/main/default/objects/Account/fields/Program_Level__c.field-meta.xml
+++ b/force-app/main/default/objects/Account/fields/Program_Level__c.field-meta.xml
@@ -11,6 +11,28 @@
     <type>Picklist</type>
     <valueSet>
         <restricted>true</restricted>
-        <valueSetName>Program_Level__gvs</valueSetName>
+        <valueSetDefinition>
+            <sorted>false</sorted>
+            <value>
+                <fullName>UG</fullName>
+                <default>false</default>
+                <label>UG</label>
+            </value>
+            <value>
+                <fullName>GR</fullName>
+                <default>false</default>
+                <label>GR</label>
+            </value>
+            <value>
+                <fullName>NC</fullName>
+                <default>false</default>
+                <label>NC</label>
+            </value>
+            <value>
+                <fullName>PHD</fullName>
+                <default>false</default>
+                <label>PHD</label>
+            </value>
+        </valueSetDefinition>
     </valueSet>
 </CustomField>

--- a/force-app/main/default/objects/Account/fields/Type__c.field-meta.xml
+++ b/force-app/main/default/objects/Account/fields/Type__c.field-meta.xml
@@ -11,6 +11,28 @@
     <type>Picklist</type>
     <valueSet>
         <restricted>true</restricted>
-        <valueSetName>Degree_Type__gvs</valueSetName>
+        <valueSetDefinition>
+            <sorted>false</sorted>
+            <value>
+                <fullName>Degree</fullName>
+                <default>false</default>
+                <label>Degree</label>
+            </value>
+            <value>
+                <fullName>Certificate</fullName>
+                <default>false</default>
+                <label>Certificate</label>
+            </value>
+            <value>
+                <fullName>Badge</fullName>
+                <default>false</default>
+                <label>Badge</label>
+            </value>
+            <value>
+                <fullName>Other</fullName>
+                <default>false</default>
+                <label>Other</label>
+            </value>
+        </valueSetDefinition>
     </valueSet>
 </CustomField>

--- a/force-app/main/default/objects/Account/fields/Unit_Type__c.field-meta.xml
+++ b/force-app/main/default/objects/Account/fields/Unit_Type__c.field-meta.xml
@@ -1,9 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
     <fullName>Unit_Type__c</fullName>
-    <description>The unit type of an academic program.</description>
+    <description>The unit type for an academic program.</description>
     <externalId>false</externalId>
-    <inlineHelpText>The unit type of an academic program.</inlineHelpText>
     <label>Unit Type</label>
     <required>false</required>
     <trackFeedHistory>false</trackFeedHistory>
@@ -11,6 +10,18 @@
     <type>Picklist</type>
     <valueSet>
         <restricted>true</restricted>
-        <valueSetName>Unit_Type__gvs</valueSetName>
+        <valueSetDefinition>
+            <sorted>false</sorted>
+            <value>
+                <fullName>Credit</fullName>
+                <default>false</default>
+                <label>Credit</label>
+            </value>
+            <value>
+                <fullName>Noncredit</fullName>
+                <default>false</default>
+                <label>Noncredit</label>
+            </value>
+        </valueSetDefinition>
     </valueSet>
 </CustomField>


### PR DESCRIPTION

# Critical Changes

* Swapped account fields from pointing to a GlobalValueSet to StandardValueSet picklist fields to handle resolve issue. Seems like a broader SF bug as per https://github.com/forcedotcom/cli/issues/1933 and https://issues.salesforce.com/issue/a028c00000gAyddAAC/during-unlocked-package-install-recordtype-upsert-is-failing-to-resolve-non-packaged-picklist

# Changes

# Issues Closed
