### PR TITLE
Only prevent offering changes if old value was not empty

### DIFF
--- a/cumulusci.yml
+++ b/cumulusci.yml
@@ -34,3 +34,10 @@ tasks:
     run_tests:
         options:
             required_org_code_coverage_percent: 75
+            
+orgs:
+    scratch:
+        dev:
+            config_file: orgs/dev.json
+            days: 7
+            namespaced: True

--- a/force-app/main/default/triggers/CSUOEE_PreventDisconnectedEnrollments.trigger
+++ b/force-app/main/default/triggers/CSUOEE_PreventDisconnectedEnrollments.trigger
@@ -6,7 +6,7 @@ trigger CSUOEE_PreventDisconnectedEnrollments on hed__Course_Enrollment__c (befo
         if(Trigger.isUpdate) {
             hed__Course_Enrollment__c old = Trigger.oldMap.get(enrollment.Id);
             if(old != null)
-                if(old.hed__Contact__c != enrollment.hed__Contact__c || old.hed__Course_Offering__c != enrollment.hed__Course_Offering__c)
+                if((old.hed__Contact__c != '' && old.hed__Contact__c != enrollment.hed__Contact__c) || (old.hed__Course_Offering__c != '' && old.hed__Course_Offering__c != enrollment.hed__Course_Offering__c))
                     enrollment.addError('Cannot change the offering or contact on an enrollment. Delete and recreate if required.');
         }
     }


### PR DESCRIPTION

# Critical Changes
Namespace now for base
# Changes
Removed course connection restriction if offering value was blanked out
# Issues Closed
