### PR TITLE
Feature/oee keys

### DIFF
--- a/force-app/main/default/classes/AzureEventIntegration.cls
+++ b/force-app/main/default/classes/AzureEventIntegration.cls
@@ -12,7 +12,7 @@ global with sharing class AzureEventIntegration {
         }
 
         try {
-            sendFutureEvents(JSON.serialize(events), isCredit);
+            sendFutureEvents(JSON.serialize(events, true), isCredit);
         } catch(CalloutException ce) {
             return new AzureResponse(uuids, false);
         }

--- a/force-app/main/default/classes/CombinedFunctions_TEST.cls
+++ b/force-app/main/default/classes/CombinedFunctions_TEST.cls
@@ -452,4 +452,22 @@ private class CombinedFunctions_TEST {
         Test.stopTest();
     }
 
+    @IsTest
+    private static void testOEEKeyHelpers() {
+        Test.startTest();
+
+        String result = OEEKeyHelpers.getKey('csuoee__Azure_Key__c');
+        System.assert(result == null);
+
+        boolean success = OEEKeyHelpers.setKey('csuoee__Azure_Key__c', 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa');
+        System.assert(!success);
+
+        success = OEEKeyHelpers.setKey('csuoee__Azure_Key__c', 'abcdefghijklmnopqrstuvwxyz');
+        System.assert(success);
+
+        System.assertEquals(OEEKeyHelpers.getKey('csuoee__Azure_Key__c'), 'abcdefghijklmnopqrstuvwxyz');
+
+        Test.stopTest();
+    }
+
 }

--- a/force-app/main/default/classes/CombinedFunctions_TEST.cls
+++ b/force-app/main/default/classes/CombinedFunctions_TEST.cls
@@ -456,16 +456,37 @@ private class CombinedFunctions_TEST {
     private static void testOEEKeyHelpers() {
         Test.startTest();
 
-        String result = OEEKeyHelpers.getKey('csuoee__Azure_Key__c');
-        System.assert(result == null);
+        try {
+            new OEEKeyEncryptor('AES', 'csuoee__Azure_Key__c', '0123456789abcdef');
+            System.assert(false);
+        } catch(SecurityException se) {
+            System.assert(true);
+        }
+
+        try {
+            new OEEKeyEncryptor('AES256', 'csuoee__Azure_Key__c', '0123456789');
+            System.assert(false);
+        } catch(SecurityException se) {
+            System.assert(true);
+        }
+
+        try {
+            new OEEKeyEncryptor('AES256', 'csuoee__Azure_Key__c', '0123456789abcdef');
+            System.assert(false);
+        } catch(QueryException se) {
+            System.assert(true);
+        }
 
         boolean success = OEEKeyHelpers.setKey('csuoee__Azure_Key__c', 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa');
         System.assert(!success);
 
-        success = OEEKeyHelpers.setKey('csuoee__Azure_Key__c', 'abcdefghijklmnopqrstuvwxyz');
+        success = OEEKeyHelpers.setKey('csuoee__Azure_Key__c', EncodingUtil.base64Encode(Crypto.generateAesKey(256)));
         System.assert(success);
 
-        System.assertEquals(OEEKeyHelpers.getKey('csuoee__Azure_Key__c'), 'abcdefghijklmnopqrstuvwxyz');
+        OEEKeyEncryptor encryptor = new OEEKeyEncryptor('AES256', 'csuoee__Azure_Key__c', '0123456789abcdef');
+        Blob encrypted = encryptor.encrypt(Blob.valueOf('abcdefghijklmnopqrstuvwxyz'));
+
+        System.assertEquals(encryptor.decrypt(encrypted).toString(), 'abcdefghijklmnopqrstuvwxyz');
 
         Test.stopTest();
     }

--- a/force-app/main/default/classes/util/OEEKeyEncryptor.cls
+++ b/force-app/main/default/classes/util/OEEKeyEncryptor.cls
@@ -1,0 +1,35 @@
+@NamespaceAccessible
+public with sharing class OEEKeyEncryptor {
+
+    private String algorithm;
+    private Blob key, iv;
+    @NamespaceAccessible
+    public OEEKeyEncryptor(String algorithm, String keyField, String iv) {
+        if(algorithm != 'AES128' && algorithm != 'AES192' && algorithm != 'AES256') {
+            throw new SecurityException('Algorithm must be one of: AES128, AES192, AES256');
+        }
+        this.algorithm = algorithm;
+
+        this.iv = Blob.valueOf(iv);
+        if(this.iv.size() != 16) {
+            throw new SecurityException('Provided IV must be of length 16.');
+        }
+
+        try {
+            this.key = EncodingUtil.base64Decode(Database.query('SELECT '+keyField+' FROM csuoee__OEE_Keys__c LIMIT 1', AccessLevel.SYSTEM_MODE).get(0).get(keyField).toString());
+        } catch(Exception e) {
+            throw new QueryException('Valid value not found for given key field name.');
+        }
+    }
+
+    @NamespaceAccessible
+    public Blob encrypt(Blob input) {
+        return Crypto.encrypt(this.algorithm, this.key, this.iv, input);
+    }
+
+    @NamespaceAccessible
+    public Blob decrypt(Blob input) {
+        return Crypto.decrypt(this.algorithm, this.key, this.iv, input);
+    }
+    
+}

--- a/force-app/main/default/classes/util/OEEKeyEncryptor.cls-meta.xml
+++ b/force-app/main/default/classes/util/OEEKeyEncryptor.cls-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>61.0</apiVersion>
+    <status>Active</status>
+</ApexClass>

--- a/force-app/main/default/classes/util/OEEKeyHelpers.cls
+++ b/force-app/main/default/classes/util/OEEKeyHelpers.cls
@@ -1,0 +1,31 @@
+global with sharing class OEEKeyHelpers {
+
+    @AuraEnabled(cacheable=false)
+    global static boolean setKey(String key, String value) {
+        csuoee__OEE_Keys__c keys;
+        try {
+            keys = [SELECT Id FROM csuoee__OEE_Keys__c LIMIT 1];
+        } catch(QueryException qe) {
+            keys = new csuoee__OEE_Keys__c();
+            insert keys;
+        }
+
+        try {
+            keys.put(key, value);
+            update keys;
+        } catch (Exception e) {
+            return false;
+        }
+
+        return true;
+    }
+
+    global static String getKey(String key) {
+        try {
+            return Database.query('SELECT '+key+' FROM csuoee__OEE_Keys__c LIMIT 1', AccessLevel.SYSTEM_MODE).get(0).get(key).toString();
+        } catch(Exception e) {
+            return null;
+        }
+    }
+    
+}

--- a/force-app/main/default/classes/util/OEEKeyHelpers.cls
+++ b/force-app/main/default/classes/util/OEEKeyHelpers.cls
@@ -19,13 +19,5 @@ global with sharing class OEEKeyHelpers {
 
         return true;
     }
-
-    global static String getKey(String key) {
-        try {
-            return Database.query('SELECT '+key+' FROM csuoee__OEE_Keys__c LIMIT 1', AccessLevel.SYSTEM_MODE).get(0).get(key).toString();
-        } catch(Exception e) {
-            return null;
-        }
-    }
     
 }

--- a/force-app/main/default/classes/util/OEEKeyHelpers.cls-meta.xml
+++ b/force-app/main/default/classes/util/OEEKeyHelpers.cls-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>61.0</apiVersion>
+    <status>Active</status>
+</ApexClass>

--- a/force-app/main/default/lwc/setOeeKey/setOeeKey.html
+++ b/force-app/main/default/lwc/setOeeKey/setOeeKey.html
@@ -1,0 +1,9 @@
+<template>
+    <table>
+        <tbody>
+            <tr><td style="vertical-align:bottom;">Key:</td><td><lightning-input lwc:ref="keyname" value={defaultkey}></lightning-input></td></tr>
+            <tr><td style="vertical-align:bottom;">Value:</td><td><lightning-input lwc:ref="valuename" placeholder="Key Value"></lightning-input></td></tr>
+            <tr><td><lightning-button onclick={handleClick} label="Update"></lightning-button></td></tr>
+        </tbody>
+    </table>
+</template>

--- a/force-app/main/default/lwc/setOeeKey/setOeeKey.js
+++ b/force-app/main/default/lwc/setOeeKey/setOeeKey.js
@@ -1,0 +1,24 @@
+import { LightningElement, api } from 'lwc';
+
+import { ShowToastEvent } from 'lightning/platformShowToastEvent';
+
+import setKey from '@salesforce/apex/OEEKeyHelpers.setKey';
+
+const UPDATE_COMPLETE = new ShowToastEvent({title: 'Set Key', message: 'Value updated.', variant: 'success'});
+const UPDATE_FAILED = new ShowToastEvent({title: 'Set Key', message: 'Value not updated.', variant: 'error'});
+
+export default class SetOeeKey extends LightningElement {
+
+    @api defaultkey;
+
+    handleClick(e) {
+        setKey({"key": this.refs.keyname.value, "value": this.refs.valuename.value}).then((result) => {
+            if(result) {
+                this.dispatchEvent(UPDATE_COMPLETE);
+            } else {
+                this.dispatchEvent(UPDATE_FAILED);
+            }
+        });
+    }
+
+}

--- a/force-app/main/default/lwc/setOeeKey/setOeeKey.js-meta.xml
+++ b/force-app/main/default/lwc/setOeeKey/setOeeKey.js-meta.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<LightningComponentBundle xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>61.0</apiVersion>
+    <isExposed>true</isExposed>
+    <masterLabel>OEE Key Setter</masterLabel>
+    <description>Hooks into @AuraEnabled Apex that allows Custom Setting updating.</description>
+    <targets>
+        <target>lightning__UtilityBar</target>
+    </targets>
+    <targetConfigs>
+        <targetConfig targets="lightning__UtilityBar">
+            <property name="defaultkey" label="Default Key Name" placeholder="csuoee__Azure_Key__c" type="String" description="The default key for this app. Can be overwritten by user."/>
+        </targetConfig>
+    </targetConfigs>
+</LightningComponentBundle>

--- a/force-app/main/default/objects/OEE_Keys__c/OEE_Keys__c.object-meta.xml
+++ b/force-app/main/default/objects/OEE_Keys__c/OEE_Keys__c.object-meta.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CustomObject xmlns="http://soap.sforce.com/2006/04/metadata">
+    <customSettingsType>Hierarchy</customSettingsType>
+    <description>Contains OEE Keys - not visible in any UI.</description>
+    <enableFeeds>false</enableFeeds>
+    <label>OEE Keys</label>
+    <visibility>Protected</visibility>
+</CustomObject>

--- a/force-app/main/default/objects/OEE_Keys__c/fields/Azure_Key__c.field-meta.xml
+++ b/force-app/main/default/objects/OEE_Keys__c/fields/Azure_Key__c.field-meta.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
+    <fullName>Azure_Key__c</fullName>
+    <description>Azure Key for event integration.</description>
+    <externalId>false</externalId>
+    <inlineHelpText>Azure Key for event integration.</inlineHelpText>
+    <label>Azure Key</label>
+    <length>255</length>
+    <required>false</required>
+    <trackTrending>false</trackTrending>
+    <type>Text</type>
+    <unique>false</unique>
+</CustomField>


### PR DESCRIPTION
Adding protected settings in the base package so we can add keys that even admins cannot see. Only the csuoee__ namespace will be allowed to interact. 

It's being used in the UTM project to encrypt PII for transit over the event grid.

# Critical Changes
Protected Custom Settings added for keys that are not visible
# Changes
LWC for utility bars that can set values
# Issues Closed
