### PR TITLE
Feature/recurring job

### DIFF
--- a/force-app/main/default/classes/background/BackgroundTest.cls
+++ b/force-app/main/default/classes/background/BackgroundTest.cls
@@ -1,0 +1,24 @@
+@IsTest
+private with sharing class BackgroundTest {
+
+    @IsTest
+    private static void emptyTest() {
+        // Just shouldn't error
+        Test.startTest();
+        System.schedule('No Data Test', EveryHour.HR_SCHEDULE, new EveryHour());
+        Test.stopTest();
+    }
+
+    @IsTest
+    private static void installTest() {
+        hed__Trigger_Handler__c fakeTask = new hed__Trigger_Handler__c(Name = 'Fake Task', hed__Object__c = 'EveryHour', hed__Active__c = true, hed__Asynchronous__c = true, hed__Class__c = 'csuoee.BackgroundTest', hed__Load_Order__c = 1, hed__Trigger_Action__c = 'Run', hed__User_Managed__c = true);
+        insert fakeTask;
+
+        OEEBasePostInstall postinstall = new OEEBasePostInstall();
+        Test.testInstall(postinstall, null);
+
+        hed__Trigger_Handler__c all = [SELECT Id FROM hed__Trigger_Handler__c WHERE hed__Object__c = 'EveryHour' AND hed__Class__c = 'csuoee.EveryHour' LIMIT 1];
+        System.Assert(all != null);
+    }
+
+}

--- a/force-app/main/default/classes/background/BackgroundTest.cls-meta.xml
+++ b/force-app/main/default/classes/background/BackgroundTest.cls-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>62.0</apiVersion>
+    <status>Active</status>
+</ApexClass>

--- a/force-app/main/default/classes/background/EveryHour.cls
+++ b/force-app/main/default/classes/background/EveryHour.cls
@@ -1,0 +1,13 @@
+global class EveryHour implements Schedulable {
+    
+    global static String HR_SCHEDULE = '0 0 * * * ?';
+    global void execute(SchedulableContext sc) {
+        // Get applicable Apex classes...
+        List<hed__Trigger_Handler__c> classes = [SELECT Id, Name, hed__Object__c, hed__Active__c, hed__Asynchronous__c, hed__Class__c, hed__Load_Order__c, hed__Trigger_Action__c, hed__User_Managed__c FROM hed__Trigger_Handler__c WHERE hed__Object__c = 'EveryHour' ORDER BY hed__Load_Order__c];
+
+        if(!ScheduleUtils.isJobActive('csuoee.EveryHour', classes)) return;
+
+        ScheduleUtils.runTasks(classes);
+    }
+
+}

--- a/force-app/main/default/classes/background/EveryHour.cls-meta.xml
+++ b/force-app/main/default/classes/background/EveryHour.cls-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>62.0</apiVersion>
+    <status>Active</status>
+</ApexClass>

--- a/force-app/main/default/classes/background/OEEBasePostInstall.cls
+++ b/force-app/main/default/classes/background/OEEBasePostInstall.cls
@@ -1,0 +1,20 @@
+global class OEEBasePostInstall implements InstallHandler {
+
+    global void onInstall(InstallContext context) {
+        hed__Trigger_Handler__c globalHrEnable;
+        try {
+            globalHrEnable = [SELECT Id, Name, hed__Object__c, hed__Active__c, hed__Asynchronous__c, hed__Class__c, hed__Load_Order__c, hed__Trigger_Action__c, hed__User_Managed__c FROM hed__Trigger_Handler__c WHERE hed__Object__c = 'EveryHour' AND hed__Class__c = 'csuoee.EveryHour' LIMIT 1];
+        } catch(QueryException qe) {
+            globalHrEnable =  null;
+        }
+        if(globalHrEnable == null) {
+            // First time setup
+            globalHrEnable = new hed__Trigger_Handler__c(Name = 'OEE Every Hour Job', hed__Object__c = 'EveryHour', hed__Active__c = true, hed__Asynchronous__c = true, hed__Class__c = 'csuoee.EveryHour', hed__Load_Order__c = 1, hed__Trigger_Action__c = 'Run', hed__User_Managed__c = true);
+            insert globalHrEnable;
+
+            // Kick it off!
+            System.schedule(globalHrEnable.Name, EveryHour.HR_SCHEDULE, new EveryHour());
+        }
+    }
+    
+}

--- a/force-app/main/default/classes/background/OEEBasePostInstall.cls-meta.xml
+++ b/force-app/main/default/classes/background/OEEBasePostInstall.cls-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>62.0</apiVersion>
+    <status>Active</status>
+</ApexClass>

--- a/force-app/main/default/classes/background/OEETask.cls
+++ b/force-app/main/default/classes/background/OEETask.cls
@@ -1,0 +1,5 @@
+public interface OEETask {
+
+    void runTask();
+    
+}

--- a/force-app/main/default/classes/background/OEETask.cls-meta.xml
+++ b/force-app/main/default/classes/background/OEETask.cls-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>62.0</apiVersion>
+    <status>Active</status>
+</ApexClass>

--- a/force-app/main/default/classes/background/ScheduleUtils.cls
+++ b/force-app/main/default/classes/background/ScheduleUtils.cls
@@ -1,0 +1,36 @@
+public class ScheduleUtils {
+
+    /**
+     * Looks for the handler that describes the schedule job itself. Check active & remove from the list since it doesn't need to run itself.
+     */
+    public static Boolean isJobActive(String scheduleClassName, List<hed__Trigger_Handler__c> classes) {
+        Integer idx = 0;
+        for(hed__Trigger_Handler__c handler : classes) {
+            if(handler.hed__Class__c == scheduleClassName) {
+                classes.remove(idx);
+                return handler.hed__Active__c;
+            }
+            idx++;
+        }
+
+        return false;
+    }
+
+    public static void runTasks(List<hed__Trigger_Handler__c> tasks) {
+        for(hed__Trigger_Handler__c task : tasks) {
+            if(task.hed__Active__c) runTask(task);
+        }
+    }
+
+    private static void runTask(hed__Trigger_Handler__c task) {
+        List<String> className = task.hed__Class__c.split('[.]');
+        if(className.get(0)!='csuoee')return;
+
+        try {
+            ((OEETask)Type.forName('csuoee', className.get(1))).runTask();
+        } catch(Exception e) {
+            // Just skip & move on
+        }
+    }
+    
+}

--- a/force-app/main/default/classes/background/ScheduleUtils.cls-meta.xml
+++ b/force-app/main/default/classes/background/ScheduleUtils.cls-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>62.0</apiVersion>
+    <status>Active</status>
+</ApexClass>


### PR DESCRIPTION

# Critical Changes

# Changes
Scheduling Framework added for recurring activities - by default only 1 hr repeatable... though we can add for weekly/monthly...
Prevents scheduling bloat (first intended use is alerting when a marketing campaign has started).

To utilize, have a class implement OEETask, and put an entry into hed__Trigger_Handler__c. 
# Issues Closed
